### PR TITLE
feat: Enable the privacy plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ markdown_extensions:
 
 plugins:
   - search
+  - privacy:
+      enabled: !ENV [CI, false]
   - section-index
   - literate-nav:
       nav_file: SUMMARY.md


### PR DESCRIPTION
这样可以让 GitHub 托管 Google Fonts。

[Built-in privacy plugin - Material for MkDocs](https://squidfunk.github.io/mkdocs-material/plugins/privacy/)

编译输出示例：https://github.com/BITNP/cheesy-shrimp/pull/4